### PR TITLE
Update umContentCreator.Core.csproj

### DIFF
--- a/umContentCreator.Core/umContentCreator.Core.csproj
+++ b/umContentCreator.Core/umContentCreator.Core.csproj
@@ -9,7 +9,6 @@
         <Title>umContentCreator.Core</Title>
         <Product>umContentCreator.Core</Product>
         <PackageId>umContentCreator.Core</PackageId>
-        <PackageTags>umbraco-marketplace</PackageTags>
         <Company>$(Authors)</Company>
         <Authors>OSKI solutions</Authors>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
It's normally not useful to list "core" projects on the Umbraco Marketplace, really just the installable component is required and likely most useful for users looking to find and install the correct package.

So this update just removes the tag from the core project, so that it would be removed on a future release.